### PR TITLE
Build Janus Debian package via dedicated repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2.1
+jobs:
+  build_deb_pkg:
+    docker:
+      - image: cimg/base:stable
+    environment:
+      PKG_VERSION: "1.0.1"
+      PKG_BUILD_NUMBER: "$(date '+%Y%m%d')"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+      - run:
+          name: Enable multiarch builds with QEMU
+          command: |
+            docker run \
+              --rm \
+              --privileged \
+              multiarch/qemu-user-static \
+              --reset \
+              -p yes
+      - run:
+          name: Create multiarch build context
+          command: docker context create builder
+      - run:
+          name: Create multiplatform builder
+          command: |
+            docker buildx create builder \
+              --name builder \
+              --driver docker-container \
+              --use
+      - run:
+          name: Ensure builder has booted
+          command: docker buildx inspect --bootstrap
+      - run:
+          name: Build docker image with .deb package
+          command: |
+            docker buildx build \
+              --platform linux/arm/v7 \
+              --build-arg PKG_VERSION \
+              --build-arg PKG_BUILD_NUMBER \
+              --target=artifact \
+              --output type=local,dest=$(pwd)/releases/ \
+              .
+      - store_artifacts:
+          path: releases
+workflows:
+  build:
+    jobs:
+      - build_deb_pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
       - image: cimg/base:stable
     environment:
       PKG_VERSION: "1.0.1"
-      PKG_BUILD_NUMBER: "$(date '+%Y%m%d')"
     steps:
       - checkout
       - setup_remote_docker:
@@ -38,7 +37,7 @@ jobs:
             docker buildx build \
               --platform linux/arm/v7 \
               --build-arg PKG_VERSION \
-              --build-arg PKG_BUILD_NUMBER \
+              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d')" \
               --target=artifact \
               --output type=local,dest=$(pwd)/releases/ \
               .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Docker artifacts.
+/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,204 @@
+# syntax=docker/dockerfile:1.4
+# Enable here-documents:
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#here-documents
+
+FROM debian:buster-20220418-slim AS build
+
+ARG PKG_NAME="janus"
+ARG PKG_VERSION="0.0.0"
+ARG PKG_BUILD_NUMBER="1"
+ARG PKG_ARCH="armhf"
+ARG PKG_ID="${PKG_NAME}_${PKG_VERSION}-${PKG_BUILD_NUMBER}_${PKG_ARCH}"
+ARG PKG_DIR="/releases/${PKG_ID}"
+ARG INSTALL_DIR="/opt/janus"
+ARG LIBNICE_VERSION="0.1.18"
+ARG LIBSRTP_VERSION="2.2.0"
+ARG LIBWEBSOCKETS_VERSION="v3.2-stable"
+
+COPY . /app
+
+RUN set -x && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      dpkg-dev
+
+# Install general-purpose packages.
+RUN apt-get install -y --no-install-recommends \
+    git \
+    wget \
+    python3-pip \
+    cmake \
+    pkg-config
+
+# Install additional libnice dependency packages.
+RUN apt-get install -y --no-install-recommends \
+    libglib2.0-dev \
+    libssl-dev \
+    ninja-build
+
+RUN pip3 install meson
+
+# Install additional Janus dependency packages.
+RUN apt-get install -y --no-install-recommends \
+    automake \
+    libtool \
+    libjansson-dev \
+    libconfig-dev \
+    gengetopt
+
+# libince is recommended to be installed from source because the version
+# installed via apt is too low.
+RUN git clone https://gitlab.freedesktop.org/libnice/libnice \
+        --branch "${LIBNICE_VERSION}" \
+        --single-branch && \
+    cd libnice && \
+    meson --prefix=/usr build && \
+    ninja -C build && \
+    ninja -C build install
+
+RUN wget "https://github.com/cisco/libsrtp/archive/v${LIBSRTP_VERSION}.tar.gz" && \
+    tar xfv "v${LIBSRTP_VERSION}.tar.gz" && \
+    cd "libsrtp-${LIBSRTP_VERSION}" && \
+    ./configure --prefix=/usr \
+        --enable-openssl && \
+    make shared_library && \
+    make install
+
+RUN git clone https://libwebsockets.org/repo/libwebsockets \
+        --branch "${LIBWEBSOCKETS_VERSION}" \
+        --single-branch && \
+    cd libwebsockets && \
+    mkdir build && \
+    cd build && \
+    cmake \
+        # https://github.com/meetecho/janus-gateway/issues/732
+        -DLWS_MAX_SMP=1 \
+        # https://github.com/meetecho/janus-gateway/issues/2476
+        -DLWS_WITHOUT_EXTENSIONS=0 \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DCMAKE_C_FLAGS="-fpic" \
+        .. && \
+    make && \
+    make install
+
+# Compile Janus.
+RUN git clone https://github.com/meetecho/janus-gateway.git \
+        --branch "${PKG_VERSION}" \
+        --single-branch && \
+    sh autogen.sh && \
+    ./configure --prefix="${INSTALL_DIR}" \
+        --disable-all-plugins \
+        --disable-all-transports \
+        --disable-all-handlers \
+        --disable-all-loggers \
+        --enable-websockets && \
+    make && \
+    make install
+
+# Allow Janus C header files to be included when compiling third-party plugins.
+# Issue: https://github.com/tiny-pilot/ansible-role-tinypilot/issues/192
+RUN sed -i -e 's|^#include "refcount.h"$|#include "../refcount.h"|g' \
+    "${INSTALL_DIR}/include/janus/plugins/plugin.h" && \
+    ln -s "${INSTALL_DIR}/include/janus" /usr/include/ || true
+
+# Ensure Janus default library directories exist.
+RUN mkdir --parents "${INSTALL_DIR}/lib/janus/plugins" \
+    "${INSTALL_DIR}/lib/janus/transports" \
+    "${INSTALL_DIR}/lib/janus/loggers"
+
+# Use Janus sample config.
+RUN mv "${INSTALL_DIR}/etc/janus/janus.jcfg.sample" \
+        "${INSTALL_DIR}/etc/janus/janus.jcfg" && \
+    mv "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg.sample" \
+        "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg"
+
+# Overwrite Janus WebSocket config.
+RUN cat > "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg" <<EOF
+general: {
+    ws = true
+    ws_ip = "127.0.0.1"
+    ws_port = 8002
+}
+EOF
+
+RUN cat > "/lib/systemd/system/janus.service" <<EOF
+[Unit]
+Description=Janus WebRTC gateway
+After=network.target
+Documentation=https://janus.conf.meetecho.com/docs/index.html
+
+[Service]
+Type=forking
+ExecStart=${INSTALL_DIR}/bin/janus --disable-colors --daemon --log-stdout
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+RUN mkdir --parents "${PKG_DIR}"
+
+# Add Janus files to the Debian package.
+RUN cp --parents --recursive --no-dereference "${INSTALL_DIR}/etc/janus" \
+    "${INSTALL_DIR}/bin/janus" \
+    "${INSTALL_DIR}/bin/janus-cfgconv" \
+    "${INSTALL_DIR}/lib/janus" \
+    "${INSTALL_DIR}/include/janus" \
+    /usr/include/janus \
+    "${INSTALL_DIR}/share/janus" \
+    "${INSTALL_DIR}/share/doc/janus-gateway" \
+    "${INSTALL_DIR}/share/man/man1/janus.1" \
+    "${INSTALL_DIR}/share/man/man1/janus-cfgconv.1" \
+    /lib/systemd/system/janus.service \
+    "${PKG_DIR}/"
+
+# Add Janus compiled shared library dependencies to the Debian package.
+RUN cp --parents --no-dereference /usr/lib/arm-linux-gnueabihf/libnice.so* \
+    /usr/lib/libsrtp2.so* \
+    /usr/lib/libwebsockets.so* \
+    "${PKG_DIR}/"
+
+RUN mkdir "${PKG_DIR}/DEBIAN"
+
+WORKDIR "${PKG_DIR}/DEBIAN"
+
+RUN cat > control <<EOF
+Package: ${PKG_NAME}
+Version: ${PKG_VERSION}
+Maintainer: TinyPilot Support <support@tinypilotkvm.com>
+Depends: libconfig9, libglib2.0-0, libjansson4, libssl1.1, libc6, libsystemd0
+Conflicts: libnice10, libsrtp2-1, libwebsockets16
+Architecture: ${PKG_ARCH}
+Homepage: https://janus.conf.meetecho.com/
+Description: An open source, general purpose, WebRTC server
+EOF
+
+RUN cat > triggers <<EOF
+# Reindex shared libraries.
+activate-noawait ldconfig
+EOF
+
+RUN cat > preinst <<EOF
+#!/bin/bash
+systemctl disable --now janus.service > /dev/null 2>&1 || true
+EOF
+RUN chmod 0555 preinst
+
+RUN cat > postinst <<EOF
+#!/bin/bash
+systemctl enable --now janus.service > /dev/null 2>&1 || true
+EOF
+RUN chmod 0555 postinst
+
+RUN cat > postrm <<EOF
+#!/bin/bash
+systemctl disable --now janus.service > /dev/null 2>&1 || true
+EOF
+RUN chmod 0555 postrm
+
+RUN dpkg --build "${PKG_DIR}"
+
+FROM scratch as artifact
+
+COPY --from=build "/releases/*.deb" ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN git clone https://libwebsockets.org/repo/libwebsockets \
 
 # Compile Janus.
 RUN git clone https://github.com/meetecho/janus-gateway.git \
-        --branch "${PKG_VERSION}" \
+        --branch "v${PKG_VERSION}" \
         --single-branch && \
     sh autogen.sh && \
     ./configure --prefix="${INSTALL_DIR}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN git clone https://libwebsockets.org/repo/libwebsockets \
 RUN git clone https://github.com/meetecho/janus-gateway.git \
         --branch "v${PKG_VERSION}" \
         --single-branch && \
+    cd janus-gateway && \
     sh autogen.sh && \
     ./configure --prefix="${INSTALL_DIR}" \
         --disable-all-plugins \

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ export PKG_BUILD_NUMBER="$(date '+%Y%m%d')"
 export DOCKER_BUILDKIT=1
 # Build Debian package.
 pushd "$(mktemp -d)" && \
-  git clone https://github.com/meetecho/janus-gateway.git \
-    --branch "v${PKG_VERSION}" \
-    --single-branch && \
+  git clone https://github.com/tiny-pilot/janus-debian.git . && \
   docker build \
     --build-arg PKG_VERSION \
     --build-arg PKG_BUILD_NUMBER \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Janus Debian Package
+
+## Overview
+
+We use Docker as a build context for creating an ARMv7 (armhf) Debian package, with precompiled Janus binaries (see the [Dockerfile](Dockerfile) for the complete build procedure). The resulting artifact is emitted to the `releases/` folder. For example:
+
+```bash
+releases/janus_1.0.1-20220513_armhf.deb
+```
+
+## Pre-requisites
+
+* Raspberry Pi OS (32bit) Buster
+* Docker
+* Git
+
+## Build
+
+On the device, run the following commands:
+
+```bash
+# Set the Janus version.
+export PKG_VERSION='1.0.1'
+export PKG_BUILD_NUMBER="$(date '+%Y%m%d')"
+# Enable new Docker BuildKit commands:
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
+export DOCKER_BUILDKIT=1
+# Build Debian package.
+pushd "$(mktemp -d)" && \
+  git clone https://github.com/meetecho/janus-gateway.git \
+    --branch "${PKG_VERSION}" \
+    --single-branch && \
+  docker build \
+    --build-arg PKG_VERSION \
+    --build-arg PKG_BUILD_NUMBER \
+    --target=artifact \
+    --output "type=local,dest=$(pwd)/releases/" \
+    .
+```
+
+## Install
+
+On the device, run the following command:
+
+```bash
+# Install Janus. This is expected to fail, if there are missing dependencies.
+# This leaves Janus installed, but unconfigured.
+sudo dpkg --install \
+  "releases/janus_${PKG_VERSION}-${PKG_BUILD_NUMBER}_armhf.deb"
+# Install the missing dependencies and complete the Janus configuration.
+sudo apt-get install --fix-broken --yes
+```
+
+You can confirm that the Janus systemd service is running, by executing the following command:
+
+```bash
+sudo systemctl status janus.service
+```
+
+## Uninstall
+
+On the device, run the following command:
+
+```bash
+sudo dpkg --purge janus
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export DOCKER_BUILDKIT=1
 # Build Debian package.
 pushd "$(mktemp -d)" && \
   git clone https://github.com/meetecho/janus-gateway.git \
-    --branch "${PKG_VERSION}" \
+    --branch "v${PKG_VERSION}" \
     --single-branch && \
   docker build \
     --build-arg PKG_VERSION \


### PR DESCRIPTION
Based on our [discussion](https://github.com/tiny-pilot/janus-gateway/pull/4#issuecomment-1130063344), this repo is meant to replace the [`janus-gateway`](https://github.com/tiny-pilot/janus-gateway) repo by being a dedicated repo for building the Janus Debian package, using Docker and CircleCI.

The code in this PR has been copied from the [`debian/` directory](https://github.com/tiny-pilot/janus-gateway/tree/f90f27cc14a2c4ac96eebf8d32d8e17c6f7efcd1/debian) and the [Dockerfile has been altered to pull directly from the official `janus-gateway` repo](https://github.com/tiny-pilot/janus-debian/blob/ad430d499557875db8677eb07712faf4d9364a41/Dockerfile#L85-L88).

You can build a new Debian package for a specific Janus version by updating the [`PKG_VERSION` environment variable](https://github.com/tiny-pilot/janus-debian/blob/257de191cf5060263f68fc424c004a45bf0376cd/.circleci/config.yml#L7) (without the `v` prefix) and pushing your changes. The resulting `.deb` file can be found as a [CircleCI job artifact](https://app.circleci.com/pipelines/github/tiny-pilot/janus-debian/4/workflows/04436844-901c-4151-b9ed-3ed7eaa56c64/jobs/4/artifacts).

Related to https://github.com/tiny-pilot/janus-gateway/issues/1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tiny-pilot/janus-debian/1)
<!-- Reviewable:end -->
