### PR TITLE
List contents of Janus Debian package during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
               --target=artifact \
               --output type=local,dest=$(pwd)/releases/ \
               .
+      - run:
+          name: List contents of Debian package
+          command: dpkg --contents janus*.deb
       - store_artifacts:
           path: releases
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
               .
       - run:
           name: List contents of Debian package
-          command: dpkg --contents janus*.deb
+          command: dpkg --contents releases/janus*.deb
       - store_artifacts:
           path: releases
 workflows:


### PR DESCRIPTION
It's helpful for refactoring the build process if we have a record of everything that's in the Debian package, similar to what we did in the TinyPilot build:

https://github.com/tiny-pilot/tinypilot/pull/1139


<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/janus-debian/4"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>