### PR TITLE
Extract Debian metadata files from Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2.1
 jobs:
+  check_bash:
+    docker:
+      - image: koalaman/shellcheck-alpine:v0.7.1
+    steps:
+      - run:
+          name: Install dependencies
+          command: apk add bash git openssh-client grep
+      - checkout
+      - run:
+          name: Run static analysis on bash scripts
+          command: ./dev-scripts/check-bash
   build_deb_pkg:
     docker:
       - image: cimg/base:stable
@@ -49,4 +60,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - build_deb_pkg
+      - check_bash
+      - build_deb_pkg:
+          requires:
+            - check_bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,10 +160,7 @@ RUN cp --parents --no-dereference /usr/lib/arm-linux-gnueabihf/libnice.so* \
     /usr/lib/libwebsockets.so* \
     "${PKG_DIR}/"
 
-RUN mkdir "${PKG_DIR}/DEBIAN"
-
 WORKDIR "${PKG_DIR}/DEBIAN"
-
 
 RUN cat > control <<EOF
 Package: ${PKG_NAME}

--- a/debian-pkg/DEBIAN/postinst
+++ b/debian-pkg/DEBIAN/postinst
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl enable --now janus.service > /dev/null 2>&1 || true

--- a/debian-pkg/DEBIAN/postinst
+++ b/debian-pkg/DEBIAN/postinst
@@ -1,2 +1,3 @@
 #!/bin/bash
+
 systemctl enable --now janus.service > /dev/null 2>&1 || true

--- a/debian-pkg/DEBIAN/postrm
+++ b/debian-pkg/DEBIAN/postrm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl disable --now janus.service > /dev/null 2>&1 || true

--- a/debian-pkg/DEBIAN/preinst
+++ b/debian-pkg/DEBIAN/preinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl disable --now janus.service > /dev/null 2>&1 || true

--- a/debian-pkg/DEBIAN/triggers
+++ b/debian-pkg/DEBIAN/triggers
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Reindex shared libraries.
+activate-noawait ldconfig

--- a/dev-scripts/check-bash
+++ b/dev-scripts/check-bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run static analysis on bash scripts.
+
+# Exit on first failing command.
+set -e
+
+# Exit on unset variable.
+set -u
+
+BASH_SCRIPTS=()
+
+while read -r filepath; do
+  if head -n 1 "${filepath}" | grep --quiet \
+    --regexp '#!/bin/bash' \
+    --regexp '#!/usr/bin/env bash' \
+    --regexp '#!/usr/sh' \
+    --regexp '#!/usr/bin/env sh' \
+    ; then
+      BASH_SCRIPTS+=("${filepath}")
+  fi
+done < <(git ls-files)
+
+readonly BASH_SCRIPTS
+
+shellcheck "${BASH_SCRIPTS[@]}"


### PR DESCRIPTION
Refactor the Debian package build so that static files live outside of the Dockerfile so we can lint them directly

This makes the layout more like what we do in the core tinypilot repo: https://github.com/tiny-pilot/tinypilot/pull/1146

To test this, I [enabled H264](https://tinypilotkvm.com/blog/whats-new-in-2022-05#enabling-h264-video) on a 2.5.0 system, removed Janus, installed this package, then rebooted. Everything worked correctly, and I confirmed that TinyPilot was streaming via WebRTC rather than MJPEG.