### PR TITLE
Remove conflicts from Debian package metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,6 @@ Package: ${PKG_NAME}
 Version: ${PKG_VERSION}
 Maintainer: TinyPilot Support <support@tinypilotkvm.com>
 Depends: libconfig9, libglib2.0-0, libjansson4, libssl1.1, libc6, libsystemd0
-Conflicts: libnice10, libsrtp2-1, libwebsockets16
 Architecture: ${PKG_ARCH}
 Homepage: https://janus.conf.meetecho.com/
 Description: An open source, general purpose, WebRTC server


### PR DESCRIPTION
We don't actually know that this package does conflict with these packages, but it does cause apt-get to refuse to install Janus when the other packages are already present.

The conflicts declaration is currently causing a clean install of TinyPilot Community to fail on Raspbian Bullseye (possibly Buster too, haven't tested).