### PR TITLE
Revert "Remove conflicts from Debian package metadata"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,7 @@ Package: ${PKG_NAME}
 Version: ${PKG_VERSION}
 Maintainer: TinyPilot Support <support@tinypilotkvm.com>
 Depends: libconfig9, libglib2.0-0, libjansson4, libssl1.1, libc6, libsystemd0
+Conflicts: libnice10, libsrtp2-1, libwebsockets16
 Architecture: ${PKG_ARCH}
 Homepage: https://janus.conf.meetecho.com/
 Description: An open source, general purpose, WebRTC server


### PR DESCRIPTION
Reverts tiny-pilot/janus-debian#7

From doing more research, I realized the `Conflicts` line does serve a purpose. We're placing files in the places where libnice10 and friends want to place files, so our package does indeed conflict with those packages.

Related: https://github.com/tiny-pilot/ansible-role-ustreamer/issues/75
Related: https://github.com/tiny-pilot/janus-debian/issues/8