### PR TITLE
Remove check_bash dependency from build_deb_pkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,4 @@ workflows:
   build:
     jobs:
       - check_bash
-      - build_deb_pkg:
-          requires:
-            - check_bash
+      - build_deb_pkg


### PR DESCRIPTION
The two steps can happen in parallel, so we don't need a dependency between the two.