### PR TITLE
Use libnice10 Debian package instead of bringing our own library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,4 @@ workflows:
   build:
     jobs:
       - check_bash
-      - build_deb_pkg:
-          requires:
-            - check_bash
+      - build_deb_pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,16 @@ RUN set -x && \
 RUN apt-get install -y --no-install-recommends \
     git \
     wget \
-    python3-pip \
     cmake \
-    libssl-dev \
     pkg-config
+
+# Install dependencies for librtsp.
+RUN apt-get install -y --no-install-recommends \
+    libssl-dev
+
+# Install dependencies for libwebsockets.
+RUN apt-get install -y --no-install-recommends \
+    zlib1g-dev
 
 # Install additional Janus dependency packages.
 RUN apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Install libnice from a custom package because the version in apt-get is too
 # old.
-ARG LIBNICE_PKG_URL="https://github.com/tiny-pilot/libnice-debian/releases/download/0.1.18-20221116/libnice10_0.1.18-20221116_armhf.deb"
+ARG LIBNICE_PKG_URL="https://github.com/tiny-pilot/libnice-debian/releases/download/0.1.18-202211161620/libnice10_0.1.18-202211161620_armhf.deb"
 RUN cd "$(mktemp --directory)" && \
     wget "${LIBNICE_PKG_URL}" && \
     dpkg --install *.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,7 @@ RUN apt-get install -y --no-install-recommends \
 
 # Install libnice from a custom package because the version in apt-get is too
 # old.
-# TODO: Replace with real URL.
-ARG LIBNICE_PKG_URL="https://p.tinypilotkvm.com/!Xu2Ex6oQoE/libnice10_0.1.18-20221116_armhf.deb"
+ARG LIBNICE_PKG_URL="https://github.com/tiny-pilot/libnice-debian/releases/download/0.1.18-20221116/libnice10_0.1.18-20221116_armhf.deb"
 RUN wget "${LIBNICE_PKG_URL}" --output-document="libnice.deb" && \
     dpkg --install libnice.deb
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -x && \
 
 # Install general-purpose packages.
 RUN apt-get install -y --no-install-recommends \
+    ca-certificates \
     git \
     wget \
     cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get install -y --no-install-recommends \
     wget \
     python3-pip \
     cmake \
+    libssl-dev \
     pkg-config
 
 # Install additional Janus dependency packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ RUN apt-get install -y --no-install-recommends \
 # Install libnice from a custom package because the version in apt-get is too
 # old.
 ARG LIBNICE_PKG_URL="https://github.com/tiny-pilot/libnice-debian/releases/download/0.1.18-20221116/libnice10_0.1.18-20221116_armhf.deb"
-RUN wget "${LIBNICE_PKG_URL}" --output-document="libnice.deb" && \
-    dpkg --install libnice.deb
+RUN cd "$(mktemp --directory)" && \
+    wget "${LIBNICE_PKG_URL}" && \
+    dpkg --install *.deb
 
 RUN wget "https://github.com/cisco/libsrtp/archive/v${LIBSRTP_VERSION}.tar.gz" && \
     tar xfv "v${LIBSRTP_VERSION}.tar.gz" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN apt-get install -y --no-install-recommends \
     libtool \
     libjansson-dev \
     libconfig-dev \
-    nice \
     gengetopt
 
 # Install libnice from a custom package because the version in apt-get is too

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,12 @@ RUN apt-get install -y --no-install-recommends \
 # Install additional Janus dependency packages.
 RUN apt-get install -y --no-install-recommends \
     automake \
+    gio-2.0 \
+    glib-2.0 \
     libtool \
     libjansson-dev \
     libconfig-dev \
+    nice \
     gengetopt
 
 # Install libnice from a custom package because the version in apt-get is too

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get install -y --no-install-recommends \
 # old.
 # TODO: Replace with real URL.
 ARG LIBNICE_PKG_URL="https://p.tinypilotkvm.com/!Xu2Ex6oQoE/libnice10_0.1.18-20221116_armhf.deb"
-RUN wget "LIBNICE_PKG_URL" --output-document="libnice.deb" && \
+RUN wget "${LIBNICE_PKG_URL}" --output-document="libnice.deb" && \
     dpkg --install libnice.deb
 
 RUN wget "https://github.com/cisco/libsrtp/archive/v${LIBSRTP_VERSION}.tar.gz" && \


### PR DESCRIPTION
This change switches the libnice10 dependency to use a custom build of the libnice10 Debian package instead of explicitly declaring the Janus package as conflicting with libnice10, which prevents the user from installing the Janus package if the system already has libnice10.

This way, the Debian package isn't responsible for installing the libnice10 package.

After we have a Debian package build that declares libnice10 as a dependency, we'll update ansible-role-ustreamer to install libnice first and then install janus:

https://github.com/tiny-pilot/ansible-role-ustreamer/pull/76

Fixes #8