### PR TITLE
Use Docker build --progress=plain for better logging in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
               --build-arg PKG_VERSION \
               --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d')" \
               --target=artifact \
+              --progress=plain \
               --output type=local,dest=$(pwd)/releases/ \
               .
       - run:


### PR DESCRIPTION
The buildx has nice logging on an interactive terminal, but in CI, it spams the logs with thousands of logs trying to update the screen. Using `--progress=plain` results in much cleaner CI output.