### PR TITLE
Use minutes-level precision in package build number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             docker buildx build \
               --platform linux/arm/v7 \
               --build-arg PKG_VERSION \
-              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d')" \
+              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d%H%M')" \
               --target=artifact \
               --progress=plain \
               --output type=local,dest=$(pwd)/releases/ \


### PR DESCRIPTION
It's possible that we'll have to build multiple times in the same day.