### PR TITLE
Reduce the instance size for the package build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   check_bash:
     docker:
       - image: koalaman/shellcheck-alpine:v0.7.1
+    resource_class: small
     steps:
       - run:
           name: Install dependencies
@@ -14,6 +15,8 @@ jobs:
   build_deb_pkg:
     docker:
       - image: cimg/base:stable
+    # We're doing a remote Docker build, so we don't need local resources.
+    resource_class: small
     environment:
       PKG_VERSION: "1.0.1"
     steps:


### PR DESCRIPTION
I realized we're barely using any CPU or RAM, so we're wasting money on the default large instance.

![image](https://user-images.githubusercontent.com/7783288/202572060-1336cfb6-4f17-48ca-8c0f-5ace3490f402.png)
