### PR TITLE
Optimize CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.24
           docker_layer_caching: true
       - run:
           name: Enable multiarch builds with QEMU

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
     docker:
       - image: cimg/base:stable
     # We're doing a remote Docker build, so we don't need local resources.
-    resource_class: small
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
           docker_layer_caching: true
       - run:
           name: Enable multiarch builds with QEMU

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,7 @@ jobs:
   build_deb_pkg:
     docker:
       - image: cimg/base:2023.06
-    # We're doing a remote Docker build, so we don't need local resources.
-    resource_class: arm.xlarge
+    resource_class: arm.large
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: ./dev-scripts/check-bash
   build_deb_pkg:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:2023.06
     # We're doing a remote Docker build, so we don't need local resources.
     resource_class: arm.xlarge
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,10 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Enable multiarch builds with QEMU
-          command: |
-            docker run \
-              --rm \
-              --privileged \
-              multiarch/qemu-user-static \
-              --reset \
-              -p yes
-      - run:
-          name: Create multiarch build context
+          name: Create build context
           command: docker context create builder
       - run:
-          name: Create multiplatform builder
+          name: Create builder
           command: |
             docker buildx create builder \
               --name builder \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,11 @@ jobs:
       - image: cimg/base:stable
     # We're doing a remote Docker build, so we don't need local resources.
     resource_class: small
-    environment:
-      PKG_VERSION: "1.0.1"
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
+          version: 20.10.14
+          docker_layer_caching: true
       - run:
           name: Enable multiarch builds with QEMU
           command: |
@@ -50,8 +49,7 @@ jobs:
           command: |
             docker buildx build \
               --platform linux/arm/v7 \
-              --build-arg PKG_VERSION \
-              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d%H%M')" \
+              --build-arg PKG_VERSION="$(date '+%Y%m%d%H%M%S')" \
               --target=artifact \
               --progress=plain \
               --output type=local,dest=$(pwd)/releases/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     docker:
       - image: cimg/base:stable
     # We're doing a remote Docker build, so we don't need local resources.
-    resource_class: xlarge
+    resource_class: arm.xlarge
     steps:
       - checkout
       - setup_remote_docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,10 +71,9 @@ RUN git clone https://libwebsockets.org/repo/libwebsockets \
     make && \
     make install
 
+# Compile Janus.
 ARG JANUS_VERSION="1.0.1"
 ARG INSTALL_DIR="/opt/janus"
-
-# Compile Janus.
 RUN git clone https://github.com/meetecho/janus-gateway.git \
         --branch "v${JANUS_VERSION}" \
         --single-branch && \
@@ -118,7 +117,7 @@ EOF
 RUN cat > "/lib/systemd/system/janus.service" <<EOF
 [Unit]
 Description=Janus WebRTC gateway
-After=network-online.target
+After=network.target
 Documentation=https://janus.conf.meetecho.com/docs/index.html
 
 [Service]

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,21 @@ RUN mkdir --parents "${INSTALL_DIR}/lib/janus/plugins" \
     "${INSTALL_DIR}/lib/janus/transports" \
     "${INSTALL_DIR}/lib/janus/loggers"
 
+# Use Janus sample config.
+RUN mv "${INSTALL_DIR}/etc/janus/janus.jcfg.sample" \
+        "${INSTALL_DIR}/etc/janus/janus.jcfg" && \
+    mv "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg.sample" \
+        "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg"
+
+# Overwrite Janus WebSocket config.
+RUN cat > "${INSTALL_DIR}/etc/janus/janus.transport.websockets.jcfg" <<EOF
+general: {
+    ws = true
+    ws_ip = "127.0.0.1"
+    ws_port = 8002
+}
+EOF
+
 RUN cat > "/lib/systemd/system/janus.service" <<EOF
 [Unit]
 Description=Janus WebRTC gateway


### PR DESCRIPTION
This makes several changes to our CircleCI build to speed up the build:

* Uses [CircleCI ARM Docker executor](https://discuss.circleci.com/t/product-launch-arm-docker-preview/48601) so we don't have to emulate through QEMU to build ARMv7 binaries.
* Enables [Docker Layer Caching](https://circleci.com/docs/docker-layer-caching/) so we can skip rebuilding parts of the Docker build image that haven't changed since last build.
* Defers Docker build args so that they're declared close to when they're first used.
  * I don't know if this is strictly required, but it makes it a little easier to read the code.

Now, it runs in seconds as opposed to previously when each run would take \~30m.