### PR TITLE
Upgrade Lintian

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,13 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: Update apt packages
-          command: apt-get update
-      - run:
           name: Install lintian
-          command: apt-get install -y lintian=2.122.0
+          command: |
+            set -eux
+            echo 'deb https://snapshot.debian.org/archive/debian/20250329T031528Z/ trixie main' \
+              > /etc/apt/sources.list.d/snapshot.list
+            apt-get update
+            apt-get install --yes lintian=2.122.0
       - run:
           name: Print lintian version
           command: lintian --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ executors:
   ubuntu:
     docker:
       - image: cimg/base:2024.02
+  debian:
+    docker:
+      - image: debian:trixie-20260202-slim
 jobs:
   check_whitespace:
     executor: ubuntu
@@ -50,17 +53,17 @@ jobs:
       - store_artifacts:
           path: build
   check_debian_package:
-    executor: ubuntu
+    executor: debian
     steps:
       - checkout
       - attach_workspace:
           at: ./
       - run:
           name: Update apt packages
-          command: sudo apt-get update
+          command: apt-get update
       - run:
           name: Install lintian
-          command: sudo apt-get install -y lintian=2.114.0ubuntu1
+          command: apt-get install -y lintian=2.122.0
       - run:
           name: Print lintian version
           command: lintian --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
           name: Install lintian
           command: |
             set -eux
+            # Add a snapshot source so that the lintian version can be pinned.
             echo 'deb https://snapshot.debian.org/archive/debian/20250329T031528Z/ trixie main' \
               > /etc/apt/sources.list.d/snapshot.list
             apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,8 @@ RUN apt-get update && \
 # Install general-purpose packages.
 RUN apt-get install --yes --no-install-recommends \
       git \
-      wget \
-      cmake \
-      meson \
-      pkg-config
+      pkg-config \
+      wget
 
 # libnice build dependencies.
 # libnice requires GLib and OpenSSL (for DTLS), and is built with Meson/Ninja.
@@ -29,14 +27,6 @@ RUN apt-get install --yes --no-install-recommends \
       libssl-dev \
       meson \
       ninja-build
-
-# Install additional Janus dependency packages.
-RUN apt-get install --yes --no-install-recommends \
-      automake \
-      libtool \
-      libjansson-dev \
-      libconfig-dev \
-      gengetopt
 
 # libince is recommended to be installed from source because the version
 # installed via apt is too low.
@@ -49,21 +39,28 @@ RUN git clone https://gitlab.freedesktop.org/libnice/libnice \
     ninja -C build && \
     ninja -C build install
 
-ARG LIBSRTP_VERSION='2.6.0'
+# libsrtp build dependencies.
+# Uses the NSS crypto backend (--enable-nss) to avoid OpenSSL symbol
+# incompatibilities, consistent with how Debian packages libsrtp2.
+RUN apt-get install --yes --no-install-recommends \
+      libnss3-dev
+
+ARG LIBSRTP_VERSION='2.7.0'
 RUN git clone https://github.com/cisco/libsrtp \
       --branch "v${LIBSRTP_VERSION}" \
       --single-branch && \
     cd libsrtp && \
-    mkdir build && \
-    cd build && \
-    cmake \
-      -DCMAKE_INSTALL_PREFIX=/usr \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DENABLE_OPENSSL=ON \
-      -DBUILD_SHARED_LIBS=ON \
-      .. && \
-    make && \
+    ./configure \
+      --prefix=/usr \
+      --enable-nss && \
+    make shared_library && \
     make install
+
+# libwebsockets build dependencies.
+# libwebsockets requires OpenSSL and is built with CMake.
+RUN apt-get install --yes --no-install-recommends \
+      cmake \
+      libssl-dev
 
 ARG LIBWEBSOCKETS_VERSION='v4.3.5'
 RUN git clone https://libwebsockets.org/repo/libwebsockets \
@@ -149,7 +146,7 @@ Priority: optional
 Maintainer: TinyPilot Support <support@tinypilotkvm.com>
 Build-Depends:
  automake,
- debhelper (>= 13),
+ debhelper (>= 11),
  dh-exec,
  gengetopt,
  libconfig-dev,

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN git clone https://github.com/cisco/libsrtp \
     make && \
     make install
 
-ARG LIBWEBSOCKETS_VERSION='v4.3.7'
+ARG LIBWEBSOCKETS_VERSION='v4.3.5'
 RUN git clone https://libwebsockets.org/repo/libwebsockets \
       --branch "${LIBWEBSOCKETS_VERSION}" \
       --single-branch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,13 +60,7 @@ RUN git clone https://github.com/cisco/libsrtp \
     make shared_library && \
     make install
 
-# libwebsockets build dependencies.
-# libwebsockets requires OpenSSL and is built with CMake.
-RUN apt-get install --yes --no-install-recommends \
-      cmake \
-      libssl-dev
-
-ARG LIBWEBSOCKETS_VERSION='v4.3.5'
+ARG LIBWEBSOCKETS_VERSION='v4.3.7'
 RUN git clone https://libwebsockets.org/repo/libwebsockets \
       --branch "${LIBWEBSOCKETS_VERSION}" \
       --single-branch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,15 @@ RUN git clone https://github.com/cisco/libsrtp \
       --branch "v${LIBSRTP_VERSION}" \
       --single-branch && \
     cd libsrtp && \
-    ./configure \
-      --prefix=/usr \
-      --enable-nss && \
-    make shared_library && \
+    mkdir build && \
+    cd build && \
+    cmake \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DENABLE_OPENSSL=ON \
+      -DBUILD_SHARED_LIBS=ON \
+      .. && \
+    make && \
     make install
 
 ARG LIBWEBSOCKETS_VERSION='v4.3.7'

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,7 @@ RUN git clone https://gitlab.freedesktop.org/libnice/libnice \
     ninja -C build && \
     ninja -C build install
 
-# libsrtp build dependencies.
-# Uses the NSS crypto backend (--enable-nss) to avoid OpenSSL symbol
-# incompatibilities, consistent with how Debian packages libsrtp2.
-RUN apt-get install --yes --no-install-recommends \
-      libnss3-dev
-
-ARG LIBSRTP_VERSION='2.7.0'
+ARG LIBSRTP_VERSION='2.2.0'
 RUN git clone https://github.com/cisco/libsrtp \
       --branch "v${LIBSRTP_VERSION}" \
       --single-branch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN git clone https://gitlab.freedesktop.org/libnice/libnice \
     ninja -C build && \
     ninja -C build install
 
-ARG LIBSRTP_VERSION='2.2.0'
+ARG LIBSRTP_VERSION='2.6.0'
 RUN git clone https://github.com/cisco/libsrtp \
       --branch "v${LIBSRTP_VERSION}" \
       --single-branch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ Priority: optional
 Maintainer: TinyPilot Support <support@tinypilotkvm.com>
 Build-Depends:
  automake,
- debhelper (>= 11),
+ debhelper (>= 13),
  dh-exec,
  gengetopt,
  libconfig-dev,

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && \
 # Install general-purpose packages.
 RUN apt-get install --yes --no-install-recommends \
       git \
-      pkg-config \
-      wget
+      wget \
+      cmake \
+      meson \
+      pkg-config
 
 # libnice build dependencies.
 # libnice requires GLib and OpenSSL (for DTLS), and is built with Meson/Ninja.
@@ -27,6 +29,14 @@ RUN apt-get install --yes --no-install-recommends \
       libssl-dev \
       meson \
       ninja-build
+
+# Install additional Janus dependency packages.
+RUN apt-get install --yes --no-install-recommends \
+      automake \
+      libtool \
+      libjansson-dev \
+      libconfig-dev \
+      gengetopt
 
 # libince is recommended to be installed from source because the version
 # installed via apt is too low.

--- a/dev-scripts/check-debian-pkg
+++ b/dev-scripts/check-debian-pkg
@@ -17,8 +17,9 @@ while read -r file; do
   # Lint Debian package.
   lintian \
     --check \
-    --no-tag-display-limit \
-    --no-cfg \
     --fail-on warning,error \
+    --no-cfg \
+    --tag-display-limit 0 \
+    --verbose \
     "${file}"
 done < <(ls -- *.deb)


### PR DESCRIPTION
Related https://github.com/tiny-pilot/tinypilot-pro/issues/1790

This PR upgrades Lintian to version `2.122.0`.

### Notes

1. As discussed [here](https://github.com/tiny-pilot/tinypilot-pro/issues/1790#issuecomment-3961994925), this PR deliberately avoids using a [CircleCI maintained convenience image](https://circleci.com/developer/images?imageType=docker) in order to use a newer Lintian version in hopes that it would flag more Debian package issues. 

<a data-ca-tag href="https://codeapprove.com/pr/tiny-pilot/janus-debian/26"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>